### PR TITLE
[FEATURE] Redirect on confirmation

### DIFF
--- a/Classes/Controller/NewsletterSubscriptionController.php
+++ b/Classes/Controller/NewsletterSubscriptionController.php
@@ -138,10 +138,23 @@ class NewsletterSubscriptionController extends ActionController
             list($valid, $message) = $this->processSubscription($isNewSubscription, $arguments);
         }
 
+        $redirectUrl = '';
+        if($this->settings['successRedirectPid'] != '') {
+
+	        $redirectUrl = $this
+		        ->uriBuilder
+		        ->reset()
+		        ->setArgumentPrefix('')
+		        ->setTargetPageUid($this->settings['successRedirectPid'])
+		        ->setCreateAbsoluteUri(true)
+		        ->uriFor(null, []);
+        }
+
         echo json_encode(
             [
                 'success' => $valid,
-                'message' => $message
+                'message' => $message,
+	            'redirect' => $redirectUrl
             ]
         );
         exit(0);

--- a/Classes/Controller/NewsletterSubscriptionController.php
+++ b/Classes/Controller/NewsletterSubscriptionController.php
@@ -106,11 +106,11 @@ class NewsletterSubscriptionController extends ActionController
             case self::STATUS_SUBSCRIBE:
                 $this->confirmSubscription($hash, $id);
 
-	            if($this->settings['confirmationRedirectPid'] != '') {
+	            if ($this->settings['confirmationRedirectPid'] !== '') {
 
 		            $arguments = [];
 
-		            if($this->settings['confirmationRedirectIncludeInfo'] != 0) {
+		            if ($this->settings['confirmationRedirectIncludeInfo'] !== 0) {
 			            $arguments['uid'] = $id;
 			            $arguments['hash'] = $this->hashService->generateRedirectHash($id);
 		            }

--- a/Classes/Service/HashService.php
+++ b/Classes/Service/HashService.php
@@ -2,10 +2,7 @@
 
 namespace Pixelant\PxaNewsletterSubscription\Service;
 
-use Pixelant\PxaNewsletterSubscription\Domain\Model\FrontendUser;
-use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 /**
  * Generate and check newsletter specific validation hashes

--- a/Classes/Service/HashService.php
+++ b/Classes/Service/HashService.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Pixelant\PxaNewsletterSubscription\Service;
+
+use Pixelant\PxaNewsletterSubscription\Domain\Model\FrontendUser;
+use TYPO3\CMS\Core\Mail\MailMessage;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
+/**
+ * Generate and check newsletter specific validation hashes
+ *
+ * Class HashService
+ * @package Pixelant\PxaNewsletterSubscription\Service
+ */
+class HashService extends \TYPO3\CMS\Extbase\Security\Cryptography\HashService
+{
+	const HASH_PREFIX_SUBSCRIPTION = 'pxa_newsletter_subscription-subscribe-';
+	const HASH_PREFIX_REDIRECT = 'pxa_newsletter_subscription-redirect-';
+
+	/**
+	 * Validate a subscription hash
+	 *
+	 * @param int $id The record uid
+	 * @param string $hash The hash to validate
+	 * @return bool True if hash is valid
+	 */
+	public function validateSubscriptionHash($id, $hash) {
+		return $this->validateHmac(self::HASH_PREFIX_SUBSCRIPTION . $id, $hash);
+	}
+
+	/**
+	 * Generate a subscription hash
+	 *
+	 * @param int $id The record uid
+	 * @return string The generated hash
+	 * @throws \TYPO3\CMS\Extbase\Security\Exception\InvalidArgumentForHashGenerationException
+	 */
+	public function generateSubscriptionHash($id) {
+		return $this->generateHmac(self::HASH_PREFIX_SUBSCRIPTION . $id);
+	}
+
+	/**
+	 * Validate a redirect hash
+	 *
+	 * @param int $id The record uid
+	 * @param string $hash The hash to validate
+	 * @return bool True if the hash is valid
+	 */
+	public function validateRedirectHash($id, $hash) {
+		return $this->validateHmac(self::HASH_PREFIX_REDIRECT . $id, $hash);
+	}
+
+	/**
+	 * Generate a redirect validation hash
+	 *
+	 * @param $id The record uid
+	 * @return string The generated hash
+	 * @throws \TYPO3\CMS\Extbase\Security\Exception\InvalidArgumentForHashGenerationException
+	 */
+	public function generateRedirectHash($id) {
+		return $this->generateHmac(self::HASH_PREFIX_REDIRECT . $id);
+	}
+
+	/**
+	 * Picks validation data from redirect url GET parameters and performs a validation
+	 *
+	 * @return bool True if hash is valid
+	 */
+	public function validateRedirectHashInGetParameters() {
+		$parameters = GeneralUtility::_GET('tx_pxanewslettersubscription_subscription');
+		return $this->validateRedirectHash($parameters['uid'], $parameters['hash']);
+	}
+}

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -12,4 +12,11 @@ plugin.tx_pxanewslettersubscription {
         # cat=plugin.tx_pxanewslettersubscription//a; type=string; label=Default storage PID
         storagePid =
     }
+
+    settings {
+        # cat=plugin.tx_pxanewslettersubscription//b; type=string; label=On success, redirect to PID
+        successRedirectPid = 
+        # cat=plugin.tx_pxanewslettersubscription//c; type=boolean; label=Include fe_user uid and security hash in redirect URL
+        successRedirectIncludeInfo = 1
+    }
 }

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -15,8 +15,8 @@ plugin.tx_pxanewslettersubscription {
 
     settings {
         # cat=plugin.tx_pxanewslettersubscription//b; type=string; label=On success, redirect to PID
-        successRedirectPid = 
+        confirmationRedirectPid =
         # cat=plugin.tx_pxanewslettersubscription//c; type=boolean; label=Include fe_user uid and security hash in redirect URL
-        successRedirectIncludeInfo = 1
+        confirmationRedirectIncludeInfo = 1
     }
 }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -138,6 +138,9 @@ plugin.tx_pxanewslettersubscription {
             class = hero-unit
             button.class = btn btn-primary btn-large
         }
+
+        successRedirectPid = {$plugin.tx_pxanewslettersubscription.settings.successRedirectPid}
+        successRedirectIncludeInfo = {$plugin.tx_pxanewslettersubscription.settings.successRedirectIncludeInfo}
     }
 
     features {

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -139,8 +139,8 @@ plugin.tx_pxanewslettersubscription {
             button.class = btn btn-primary btn-large
         }
 
-        successRedirectPid = {$plugin.tx_pxanewslettersubscription.settings.successRedirectPid}
-        successRedirectIncludeInfo = {$plugin.tx_pxanewslettersubscription.settings.successRedirectIncludeInfo}
+        confirmationRedirectPid = {$plugin.tx_pxanewslettersubscription.settings.confirmationRedirectPid}
+        confirmationRedirectIncludeInfo = {$plugin.tx_pxanewslettersubscription.settings.confirmationRedirectIncludeInfo}
     }
 
     features {

--- a/Resources/Public/Js/Form.js
+++ b/Resources/Public/Js/Form.js
@@ -30,10 +30,14 @@
 			formElement.after(message);
 
 			if (response.success) {
-				// display message
-				message.addClass('alert-success');
-				// hide form
-				formElement.hide();
+				if(response.redirect != '') {
+					$(location).attr('href', response.redirect);
+				} else {
+					// display message
+					message.addClass('alert-success');
+					// hide form
+					formElement.hide();
+				}
 			} else {
 				// display message and set message to disapear after 5 sec.
 				message.addClass('alert-danger').delay(5000).fadeOut('slow');

--- a/Resources/Public/Js/Form.js
+++ b/Resources/Public/Js/Form.js
@@ -30,14 +30,10 @@
 			formElement.after(message);
 
 			if (response.success) {
-				if(response.redirect != '') {
-					$(location).attr('href', response.redirect);
-				} else {
-					// display message
-					message.addClass('alert-success');
-					// hide form
-					formElement.hide();
-				}
+				// display message
+				message.addClass('alert-success');
+				// hide form
+				formElement.hide();
 			} else {
 				// display message and set message to disapear after 5 sec.
 				message.addClass('alert-danger').delay(5000).fadeOut('slow');


### PR DESCRIPTION
- Introduces a TypoScript configuration option `confirmationRedirectPid` to specify what PID to redirect to, following successful subscription confirmation.

- Introduces a boolean TypoScript configuration option `confirmationRedirectIncludeInfo`, to enable the inclusion of fe_user uid and a validation hash to make sure the uid has not been changed by a third party.

- Moves hashing generation and validation into the class `HashService`. This gives a unified approach to hashing within the extension and avoids static parts of hashing strings being repeated in multiple places. It also enables third-party extensions to validate and generate validation strings more easily.

- Introduces functions in `HashService` to enable generation and validation of redirect hashes.

- Introduces a convenience function in `HashService`, validating a redirect hash in the GET parameters. This gives third-party extensions the possibility to validate a hash without knowing the names of the GET parameters used.